### PR TITLE
Handle Windows permission errors correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ force-symlink
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 Like `fs.symlink`, but friendlier.
-Handles *ENOENT* and *EEXIST* errors.
+Handles *ENOENT*, *EEXIST* and *EPERM* errors.
 
 Usage
 -----

--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ function handleENOENT (srcPath, dstPath, type, cb) {
   })
 }
 
+function handleEPERM (srcPath, dstPath, type, cb) {
+  forceSymlink(srcPath, dstPath, 'junction', function (err) {
+    return cb(err)
+  })
+}
+
 function forceSymlink (srcPath, dstPath, type, cb) {
   cb = typeof type === 'function' ? type : cb
   type = typeof type === 'string' ? type : null
@@ -34,6 +40,11 @@ function forceSymlink (srcPath, dstPath, type, cb) {
 
     if (err && err.code === 'EEXIST') {
       handleEEXIST(srcPath, dstPath, type, cb)
+      return
+    }
+
+    if (err && err.code === 'EPERM') {
+      handleEPERM(srcPath, dstPath, type, cb)
       return
     }
 

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ function cleanup (t) {
 }
 
 function removeTrailingSlash(linkString) {
-  return linkString.replace(/[\/\\\\]$/, '')
+  return linkString.replace(/[\/\\]$/, '')
 }
 
 function verify (t) {

--- a/test.js
+++ b/test.js
@@ -25,10 +25,16 @@ function cleanup (t) {
   })
 }
 
+function removeTrailingSlash(linkString) {
+  return linkString.replace(/[\/\\\\]$/, '')
+}
+
 function verify (t) {
   t.test('verify', function (t) {
     fs.readlink(path.join(sandbox, 'some-link'), function (err, linkString) {
-      t.equal(linkString, '../some-file', 'should have created a symlink to "../some-file"')
+      //Nodejs on Windows will add a trailing slash
+      linkString = linkString ? removeTrailingSlash(linkString) : linkString
+      t.equal(linkString, path.resolve('../some-file'), 'should have created a symlink to "../some-file"')
       t.end(err)
     })
   })
@@ -39,7 +45,7 @@ test('when symlink doesn\'t exist', function (t) {
   setup(t)
 
   t.test('it should create the symlink', function (t) {
-    forceSymlink('../some-file', path.join(sandbox, 'some-link'), function (err) {
+    forceSymlink(path.resolve('../some-file'), path.join(sandbox, 'some-link'), function (err) {
       t.end(err)
     })
   })
@@ -53,13 +59,13 @@ test('when symlink already exists', function (t) {
   setup(t)
 
   t.test('setup incorrect symlink', function (t) {
-    fs.symlink('../some-other-file', path.join(sandbox, 'some-link'), function (err) {
+    fs.symlink(path.resolve('../some-other-file'), path.join(sandbox, 'some-link'), 'junction', function (err) {
       t.end(err)
     })
   })
 
   t.test('it should unlink and create a new symlink', function (t) {
-    forceSymlink('../some-file', path.join(sandbox, 'some-link'), function (err) {
+    forceSymlink(path.resolve('../some-file'), path.join(sandbox, 'some-link'), function (err) {
       t.end(err)
     })
   })
@@ -72,7 +78,7 @@ test('when containing directory doesn\'t exist', function (t) {
   cleanup(t)
 
   t.test('mkdirp the directory and create a new symlink', function (t) {
-    forceSymlink('../some-file', path.join(sandbox, 'some-link'), function (err) {
+    forceSymlink(path.resolve('../some-file'), path.join(sandbox, 'some-link'), function (err) {
       t.end(err)
     })
   })
@@ -86,7 +92,7 @@ test('when type is given', function (t) {
   setup(t)
 
   t.test('it should invoke the callback', function (t) {
-    forceSymlink('../some-file', path.join(sandbox, 'some-link'), 'dir', function (err) {
+    forceSymlink(path.resolve('../some-file'), path.join(sandbox, 'some-link'), 'dir', function (err) {
       t.end(err)
     })
   })


### PR DESCRIPTION
Creating symlinks on Windows can give an error since it needs administrator permissions. The option we have is to use [junction](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365006%28v=vs.85%29.aspx) links. 

This pull requests is written for issue's I have with ied on Windows. The [issue](https://github.com/alexanderGugel/ied/issues/35) for ied was already solved in [a PR](https://github.com/alexanderGugel/ied/pull/95) but was reintroduced by a [rewrite](https://github.com/alexanderGugel/ied/commit/8fb0a0795894813894faaebe74d4ad7273f4e592) of ied.

PS: I changed the tests a little bit to get them working on Windows too.
